### PR TITLE
Fix basic usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 flash:
+	go run cmd/main.go -conf=tinygo
 	tinygo flash -target pybadge .
 
 flash-gceu:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 flash:
-	go run cmd/main.go -conf=tinygo
+	go run cmd/main.go
 	tinygo flash -target pybadge .
 
 flash-gceu:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,7 +15,7 @@ const (
 )
 
 func main() {
-	conf := flag.String("conf", "", "Choose the conference logo you want to (e.g.: tinygo, gceu22, gcuk22, gcus22)")
+	conf := flag.String("conf", tinygoLogo, "Choose the conference logo you want to (e.g.: tinygo, gceu22, gcuk22, gcus22)")
 	flag.Parse()
 
 	c := confs()

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/tinygo-org/gobadge
 go 1.15
 
 require (
-	tinygo.org/x/drivers v0.20.1-0.20220514193317-9409d60eb2e5
+	tinygo.org/x/drivers v0.21.0
 	tinygo.org/x/tinydraw v0.3.0
 	tinygo.org/x/tinyfont v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ tinygo.org/x/drivers v0.14.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2
 tinygo.org/x/drivers v0.15.1/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/drivers v0.16.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/drivers v0.19.0/go.mod h1:uJD/l1qWzxzLx+vcxaW0eY464N5RAgFi1zTVzASFdqI=
-tinygo.org/x/drivers v0.20.1-0.20220514193317-9409d60eb2e5 h1:kEVuQdoE6e9tn+pX/nCcyAsGmNOv12jY2GTYMB0FFq0=
-tinygo.org/x/drivers v0.20.1-0.20220514193317-9409d60eb2e5/go.mod h1:uJD/l1qWzxzLx+vcxaW0eY464N5RAgFi1zTVzASFdqI=
+tinygo.org/x/drivers v0.21.0 h1:4jasPGeHEo+clHqU2bothSYbmncc+u8nN0VMAmJ7IRg=
+tinygo.org/x/drivers v0.21.0/go.mod h1:uJD/l1qWzxzLx+vcxaW0eY464N5RAgFi1zTVzASFdqI=
 tinygo.org/x/tinydraw v0.3.0 h1:OjsdMcES5+7IIs/4diFpq/pWFsa0VKtbi1mURuj2q64=
 tinygo.org/x/tinydraw v0.3.0/go.mod h1:Yz0vLSP2rHsIKpLYkEmLnE+2zyhhITu2LxiVtLRiW6I=
 tinygo.org/x/tinyfont v0.2.1/go.mod h1:eLqnYSrFRjt5STxWaMeOWJTzrKhXqpWw7nU3bPfKOAM=


### PR DESCRIPTION
I've received my pybadge and tried to just "make flash" and had the following problems:

* `tinygo.org/x/drivers v0.20.1-0.20220514193317-9409d60eb2e5` not found => upgrade to latest v0.21.0
* `logoRGBA` not defined => it makes no sense to flash without a logo, so let's use tinygo's logo by default

This way newcomers can use it out of the box.