### PR TITLE
menu: faster background drawing using FastHLines

### DIFF
--- a/menu.go
+++ b/menu.go
@@ -11,6 +11,75 @@ import (
 	"tinygo.org/x/tinyfont/proggy"
 )
 
+// FilledTriangle draws a filled triangle given three points
+// Code from tinydraw, but faster and may not work on all displays
+func FilledTriangle(x0 int16, y0 int16, x1 int16, y1 int16, x2 int16, y2 int16, color color.RGBA) {
+    if y0 > y1 {
+        x0, y0, x1, y1 = x1, y1, x0, y0
+    }
+    if y1 > y2 {
+        x1, y1, x2, y2 = x2, y2, x1, y1
+    }
+    if y0 > y1 {
+        x0, y0, x1, y1 = x1, y1, x0, y0
+    }
+
+    if y0 == y2 { // y0 = y1 = y2 : it's a line
+        a := x0
+        b := x0
+        if x1 < a {
+            a = x1
+        } else if x1 > b {
+            b = x1
+        }
+        if x2 < a {
+            a = x2
+        } else if x2 > b {
+            b = x2
+        }
+        // Line(display, a, y0, b, y0, color)
+        display.DrawFastHLine(a, b, y0, color)
+        return
+    }
+
+    dx01 := x1 - x0
+    dy01 := y1 - y0
+    dx02 := x2 - x0
+    dy02 := y2 - y0
+    dx12 := x2 - x1
+    dy12 := y2 - y1
+
+    sa := int16(0)
+    sb := int16(0)
+    a := int16(0)
+    b := int16(0)
+
+    last := y1 - 1
+    if y1 == y2 {
+        last = y1
+    }
+
+    y := y0
+    for ; y <= last; y++ {
+        a = x0 + sa/dy01
+        b = x0 + sb/dy02
+        sa += dx01
+        sb += dx02
+        display.DrawFastHLine(a, b, y, color)
+    }
+
+    sa = dx12 * (y - y1)
+    sb = dx02 * (y - y0)
+
+    for ; y <= y2; y++ {
+        a = x1 + sa/dy12
+        b = x0 + sb/dy02
+        sa += dx12
+        sb += dx02
+        display.DrawFastHLine(a, b, y, color)
+    }
+}
+
 func menu() int16 {
 	display.FillScreen(color.RGBA{0, 0, 0, 255})
 	options := []string{
@@ -23,12 +92,12 @@ func menu() int16 {
 
 	bgColor := color.RGBA{0, 40, 70, 255}
 	display.FillScreen(bgColor)
-	tinydraw.FilledTriangle(&display, 0, 128, 0, 45, 45, 0, color.RGBA{255, 255, 255, 255})
-	tinydraw.FilledTriangle(&display, 45, 0, 0, 128, 145, 0, color.RGBA{255, 255, 255, 255})
-	tinydraw.FilledTriangle(&display, 0, 128, 15, 128, 145, 0, color.RGBA{255, 255, 255, 255})
-	for i := int16(0); i < 8; i++ {
-		tinydraw.Line(&display, 0, 110+i, 110+i, 0, bgColor)
-	}
+	FilledTriangle(0, 128, 0, 45, 45, 0, color.RGBA{255, 255, 255, 255})
+	FilledTriangle(45, 0, 0, 128, 145, 0, color.RGBA{255, 255, 255, 255})
+	FilledTriangle(0, 128, 15, 128, 145, 0, color.RGBA{255, 255, 255, 255})
+
+	FilledTriangle(0, 110, 110, 0, 117, 0, bgColor) 
+	FilledTriangle(0, 110, 0, 117, 117, 0, bgColor) 
 
 	selected := int16(0)
 	numOpts := int16(len(options))


### PR DESCRIPTION
I improved menu's background drawing by using a customized version of `FilledTriangle`, which relies on `DrawFastHLine` rather than pixel-by-pixel line drawing.

I have mixed feelings:
* it would be better to do this in `tinydraw`
* but I think not all drivers support `DrawFastHLine`
* that is why I copied `FilledTriangle` here, but if you have a better solution I'd love to hear about.

I'm a beginner with go, so there may be a trick I don't know :wink: 
The aim of this PR is mostly to have your feedback.

Overall there's a lot of potential in performance improvement with batching pixel drawings and using driver-specific functions when available, but I guess if there was an easy way to do it it would already be done :shrug: 