### PR TITLE
badge: allows user to set the name and title info displayed on the badge using Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,24 @@
 flash: flash-tinygo
 
-flash-gceu:
+prepare-gceu:
 	go run cmd/main.go -conf=gceu22
-	tinygo flash -size short -target pybadge .
 
-flash-gcuk:
+flash-gceu: prepare-gceu perform-flash
+
+prepare-gcuk:
 	go run cmd/main.go -conf=gcuk22
-	tinygo flash -size short -target pybadge .
 
-flash-gcus:
+flash-gcuk: prepare-gcuk perform-flash
+
+prepare-gcus:
 	go run cmd/main.go -conf=gcus22
-	tinygo flash -size short -target pybadge .
 
-flash-tinygo:
+flash-gcus: prepare-gcus perform-flash
+
+prepare-tinygo:
 	go run cmd/main.go -conf=tinygo
-	tinygo flash -size short -target pybadge .
 
+flash-tinygo: prepare-tinygo perform-flash
+
+perform-flash:
+	tinygo flash -size short -target pybadge -ldflags="-X main.YourName='$(NAME)' -X main.YourTitle1='$(TITLE1)' -X main.YourTitle2='$(TITLE2)'" .

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ https://www.adafruit.com/product/4200
 
 - Change directories into the directory with the repo
 
-- Customize the file `data.go` with your own name and information
-
 - Connect your Pybadge to your computer using a USB cable
 
 - Run this command to compile and flash the code to your Pybadge:
@@ -35,11 +33,18 @@ make flash-gcuk
 make flash-gcus
 ```
 
+- To customize the Gobadge with your own name and information, use the `NAME`, `TITLE1`, and `TITLE2` variables like this:
+
+```
+make flash-gcus NAME="@TinyGolang" TITLE1="Go compiler" TITLE2="small places"
+```
+
 # Add an new logo
 
 - Create an image with a 160x128 pixels size, copy it into `cmd/assets` folder.  
 For the moment only jpeg images are supported.  
 - In `cmd/main.go` add the path to your file here
+
 ```go
 const (
 gopherconEU22Logo = "./cmd/assets/gopherconeu-2022.jpg"
@@ -48,7 +53,9 @@ gopherconUS22Logo = "./cmd/assets/gopherconus-2022.jpg"
 yourPathLogoHere = "./your/path/to/the/logo"
 )
 ```
+
 - Add the corresponding flag to the conf map:
+
 ```go
 func confs() map[string]string {
 	return map[string]string{
@@ -61,6 +68,7 @@ func confs() map[string]string {
 ```
 
 Add a new target to the Makefile:
+
 ```bash
 flash-yourconf:
 	go run cmd/main.go -conf=flagLogo
@@ -68,12 +76,14 @@ flash-yourconf:
 ```
 
 You can run:
+
 ```bash
 make flash-yourconf
 ```
 
 It will use `cmd/logos/logo-template.txt` to generate the image into a `[]color.RGBA`.
 Then it is stored in variable in `logo.go` file.
+
 ```go
 package main
 

--- a/badge.go
+++ b/badge.go
@@ -37,6 +37,7 @@ var pressed uint8
 var quit bool
 
 func Badge() {
+	setNameAndTitle()
 	quit = false
 	display.FillScreen(colors[BLACK])
 
@@ -62,7 +63,7 @@ func Badge() {
 		if quit {
 			break
 		}
-		blinkyRainbow("Hack Session", "29th All Day")
+		blinkyRainbow("Hack Session", "Oct 6 All Day")
 		if quit {
 			break
 		}
@@ -193,4 +194,18 @@ func scroll(topline, middleline, bottomline string) {
 func logo() {
 	display.FillRectangleWithBuffer(0, 0, WIDTH, HEIGHT, logoRGBA)
 	time.Sleep(logoDisplayTime)
+}
+
+func setNameAndTitle() {
+	if YourName == "" {
+		YourName = DefaultName
+	}
+
+	if YourTitle1 == "" {
+		YourTitle1 = DefaultTitle1
+	}
+
+	if YourTitle2 == "" {
+		YourTitle2 = DefaultTitle2
+	}
 }

--- a/data.go
+++ b/data.go
@@ -1,8 +1,17 @@
 package main
 
-// Replace with your data.
+// Replace with your data by using -ldflags like this:
+//
+// tinygo flash -target pybadge -ldflags="-X main.YourName=@myontwitter -X main.YourTitle1='Amazing human' -X main.YourTitle2='also kind'"
+//
+// See Makefile for more info.
+//
+var (
+	YourName, YourTitle1, YourTitle2 string
+)
+
 const (
-	YourName   = "@_conejo"
-	YourTitle1 = "technologist"
-	YourTitle2 = "FOR HIRE"
+	DefaultName   = "@TinyGolang"
+	DefaultTitle1 = "Go Compiler"
+	DefaultTitle2 = "Small Places"
 )


### PR DESCRIPTION
This PR allows user to set the name and title info displayed on the badge using the new Makefile arguments `NAME`, `TITLE1`, and `TITLE2`.

How to use:

```
make flash-gcus NAME="@TinyGolang" TITLE1="Go compiler" TITLE2="small places"
```

It also refactors the Makefile a bit to remove duplication.