### PR TITLE
tutorials: adding flight controller using badge as combo HID keyboard/CDC serial device

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/tinygo-org/gobadge
 go 1.15
 
 require (
-	tinygo.org/x/drivers v0.22.0
+	tinygo.org/x/drivers v0.23.0
 	tinygo.org/x/tinydraw v0.3.0
 	tinygo.org/x/tinyfont v0.3.0
+	tinygo.org/x/tinyterm v0.2.1-0.20221003142551-ae75982d313f
 )

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ tinygo.org/x/drivers v0.14.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2
 tinygo.org/x/drivers v0.15.1/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/drivers v0.16.0/go.mod h1:uT2svMq3EpBZpKkGO+NQHjxjGf1f42ra4OnMMwQL2aI=
 tinygo.org/x/drivers v0.19.0/go.mod h1:uJD/l1qWzxzLx+vcxaW0eY464N5RAgFi1zTVzASFdqI=
-tinygo.org/x/drivers v0.22.0 h1:s5c0hJY8pJYojSGS5AQgauwhTuH2bBZPDqdwkBDGW+o=
-tinygo.org/x/drivers v0.22.0/go.mod h1:J4+51Li1kcfL5F93kmnDWEEzQF3bLGz0Am3Q7E2a8/E=
+tinygo.org/x/drivers v0.23.0 h1:fUy4OmLOWWYCOzDp/83Qewej1Q+YgUpwkm11e7gxUc0=
+tinygo.org/x/drivers v0.23.0/go.mod h1:J4+51Li1kcfL5F93kmnDWEEzQF3bLGz0Am3Q7E2a8/E=
 tinygo.org/x/tinydraw v0.3.0 h1:OjsdMcES5+7IIs/4diFpq/pWFsa0VKtbi1mURuj2q64=
 tinygo.org/x/tinydraw v0.3.0/go.mod h1:Yz0vLSP2rHsIKpLYkEmLnE+2zyhhITu2LxiVtLRiW6I=
 tinygo.org/x/tinyfont v0.2.1/go.mod h1:eLqnYSrFRjt5STxWaMeOWJTzrKhXqpWw7nU3bPfKOAM=
@@ -35,3 +35,5 @@ tinygo.org/x/tinyfont v0.3.0/go.mod h1:+TV5q0KpwSGRWnN+ITijsIhrWYJkoUCp9MYELjKpA
 tinygo.org/x/tinyfs v0.1.0/go.mod h1:ysc8Y92iHfhTXeyEM9+c7zviUQ4fN9UCFgSOFfMWv20=
 tinygo.org/x/tinyfs v0.2.0/go.mod h1:6ZHYdvB3sFYeMB3ypmXZCNEnFwceKc61ADYTYHpep1E=
 tinygo.org/x/tinyterm v0.1.0/go.mod h1:/DDhNnGwNF2/tNgHywvyZuCGnbH3ov49Z/6e8LPLRR4=
+tinygo.org/x/tinyterm v0.2.1-0.20221003142551-ae75982d313f h1:QZKIR/NSAWOwR3Uv5hYzwgtSsReOWZNCqK2NlmPylgA=
+tinygo.org/x/tinyterm v0.2.1-0.20221003142551-ae75982d313f/go.mod h1:ii6r/nCtNVRQgac21uQj9tlY3PnJuUAcZWMLgdVwMFo=

--- a/tutorial/flightbadge/main.go
+++ b/tutorial/flightbadge/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"time"
+
+	"machine/usb/hid/keyboard"
+
+
+	"tinygo.org/x/drivers/shifter"
+)
+
+var (
+	shifted bool
+	lastKey string
+	lastTime time.Time
+)
+
+func main() {
+	buttons := shifter.NewButtons()
+	buttons.Configure()
+
+	for {
+		buttons.ReadInput()
+
+		// takeoff
+		if buttons.Pins[shifter.BUTTON_START].Get() {
+			handleKey("[")
+		}
+
+		// land
+		if buttons.Pins[shifter.BUTTON_A].Get() {
+			handleKey("]")
+		}
+
+		// front flip
+		if buttons.Pins[shifter.BUTTON_SELECT].Get() {
+			handleKey("t")
+		}
+
+		// hold down button B to shift to access second set of arrow commands
+		if buttons.Pins[shifter.BUTTON_B].Get() {
+			shifted = true
+		} else {
+			shifted = false
+		}
+
+		if buttons.Pins[shifter.BUTTON_LEFT].Get() {
+			handleShiftedKey("j", "a")
+		}
+
+		if buttons.Pins[shifter.BUTTON_UP].Get() {
+			handleShiftedKey("i", "w")
+		}
+
+		if buttons.Pins[shifter.BUTTON_DOWN].Get() {
+			handleShiftedKey("k", "s")
+		}
+
+		if buttons.Pins[shifter.BUTTON_RIGHT].Get() {
+			handleShiftedKey("l", "d")
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func handleShiftedKey(key1, key2 string) {
+	if shifted {
+		handleKey(key1)
+		return
+	}
+	handleKey(key2)
+}
+
+func handleKey(key string) {
+	// simple debounce
+	if key == lastKey && time.Since(lastTime) < 150 * time.Millisecond {
+		return
+	}
+
+	kb := keyboard.New()
+	kb.Write([]byte(key))
+
+	lastKey, lastTime = key, time.Now()
+}

--- a/tutorial/terminal/main.go
+++ b/tutorial/terminal/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"image/color"
+	"time"
+
+	"machine"
+
+	"tinygo.org/x/drivers/st7735"
+
+	"tinygo.org/x/tinyfont/proggy"
+	"tinygo.org/x/tinyterm"
+)
+
+var (
+	uart = machine.Serial
+
+	display = st7735.New(machine.SPI1, machine.TFT_RST, machine.TFT_DC, machine.TFT_CS, machine.TFT_LITE)
+
+	terminal = tinyterm.NewTerminal(&display)
+
+	black = color.RGBA{0, 0, 0, 255}
+	white = color.RGBA{255, 255, 255, 255}
+	red   = color.RGBA{255, 0, 0, 255}
+	blue  = color.RGBA{0, 0, 255, 255}
+	green = color.RGBA{0, 255, 0, 255}
+
+	font = &proggy.TinySZ8pt7b
+)
+
+func main() {
+	machine.SPI1.Configure(machine.SPIConfig{
+		SCK:       machine.SPI1_SCK_PIN,
+		SDO:       machine.SPI1_SDO_PIN,
+		SDI:       machine.SPI1_SDI_PIN,
+		Frequency: 8000000,
+	})
+
+	display.Configure(st7735.Config{
+		Rotation: st7735.ROTATION_90,
+	})
+
+	display.FillScreen(black)
+
+	terminal.Configure(&tinyterm.Config{
+		Font:              font,
+		FontHeight:        10,
+		FontOffset:        6,
+		UseSoftwareScroll: true,
+	})
+
+	input := make([]byte, 64)
+	i := 0
+	for {
+		if uart.Buffered() > 0 {
+			data, _ := uart.ReadByte()
+
+			switch data {
+			case 13:
+				// return key
+				uart.Write([]byte("\r\n"))
+				uart.Write([]byte("You typed: "))
+				uart.Write(input[:i])
+				uart.Write([]byte("\r\n"))
+
+				terminal.Write([]byte("\r\n"))
+				terminal.Write([]byte("You typed: "))
+				terminal.Write(input[:i])
+				terminal.Write([]byte("\r\n"))
+
+				i = 0
+			default:
+				// just echo the character
+				uart.WriteByte(data)
+				input[i] = data
+
+				terminal.WriteByte(data)
+				i++
+			}
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
This PR adds to the tutorials section an example showing using the gobadge as HID keyboard device/serial device to function as a drone/robot gamepad style controller.

It also adds an example showing using the Gobadge as a sort of simple connected monitor when doing a serial port echo like in the main TinyGo examples.