### PR TITLE
Fix `make perform-flash`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,4 @@ prepare-fosdem:
 flash-fosdem: prepare-fosdem perform-flash
 
 perform-flash:
-	tinygo flash -size short -target pybadge -ldflags="-X main.YourName='$(NAME)' -X main.YourTitle1='$(TITLE1)' -X main.YourTitle2='$(TITLE2)'" .
+	tinygo flash -size short -target pybadge -ldflags="-X main.YourName='$(NAME)' -X main.YourTitleA1='$(TITLE1)' -X main.YourTitleA2='$(TITLE2)'" .


### PR DESCRIPTION
The commit https://github.com/tinygo-org/gobadge/commit/bf91bd0c1dd12aefc0fc2052ebd86644955607e4 slightly broke the installation process described in the readme. When I do `make flash` I get an error:

```
$ make flash
go run cmd/main.go -conf=tinygo
tinygo flash -size short -target pybadge -ldflags="-X main.YourName='' -X main.YourTitle1='' -X main.YourTitle2=''" .
error: global not found: main.YourTitle1
make: *** [Makefile:29: perform-flash] Error 1
```

The MR adjusts the `perform-flash` command to use the new variable names.