### PR TITLE
all: target name is now gobadge, and add note about new badges

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ prepare-fosdem:
 flash-fosdem: prepare-fosdem perform-flash
 
 perform-flash:
-	tinygo flash -size short -target pybadge -ldflags="-X main.YourName='$(NAME)' -X main.YourTitleA1='$(TITLE1)' -X main.YourTitleA2='$(TITLE2)'" .
+	tinygo flash -size short -target gobadge -ldflags="-X main.YourName='$(NAME)' -X main.YourTitleA1='$(TITLE1)' -X main.YourTitleA2='$(TITLE2)'" .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GoBadge
 
-TinyGo powered badge using the Adafruit Pybadge hardware.
+TinyGo powered badge using the Adafruit Pybadge hardware aka "GoBadge".
 
 https://www.adafruit.com/product/4200
 
@@ -12,13 +12,16 @@ https://www.adafruit.com/product/4200
 
 - Change directories into the directory with the repo
 
-- Connect your Pybadge to your computer using a USB cable
+- Connect your Gobadge to your computer using a USB cable
 
 - Make sure to turn on the badge, flip the switch at the top of the board next to `select` to the `on` position. The screen should light up and might be showing a sine wave display (if it was not already flashed to something else).
 ![location of on off switch](assets/on_off.jpg "on off switch location")
 
+***Important Note***
 
-- Run this command to compile and flash the code to your Pybadge:
+The first time you flash your new GoBadge, you will probably need to double-click the "Reset" button located on the back of the badge in order to put the badge into bootloader mode. This will only need to be done once on brand new badges, after that you can flash it normally.
+
+- Run this command to compile and flash the code to your Gobadge:
 
 If you are running Mac or Linux, or have make installed you can run the following:
 
@@ -29,7 +32,7 @@ make flash
 otherwise run tinygo directly
 
 ```
-tinygo flash -target pybadge .
+tinygo flash -target gobadge .
 ```
 
 Note: if you get a `permision denied` error; please, consult this [page](https://tinygo.org/docs/guides/tinygo-flash-errors/) for possible solution. You many need to restart the computer; afterward to get the group to stick.
@@ -80,7 +83,7 @@ Add a new target to the Makefile:
 ```bash
 flash-yourconf:
 	go run cmd/main.go -conf=flagLogo
-	tinygo flash -target pybadge .
+	tinygo flash -target gobadge .
 ```
 
 You can run:

--- a/data.go
+++ b/data.go
@@ -2,7 +2,7 @@ package main
 
 // Replace with your data by using -ldflags like this:
 //
-// tinygo flash -target pybadge -ldflags="-X main.YourName=@myontwitter -X main.YourTitle1='Amazing human' -X main.YourTitle2='also kind'"
+// tinygo flash -target gobadge -ldflags="-X main.YourName=@myontwitter -X main.YourTitle1='Amazing human' -X main.YourTitle2='also kind'"
 //
 // See Makefile for more info.
 var (

--- a/tutorial/basics/README.md
+++ b/tutorial/basics/README.md
@@ -50,7 +50,7 @@ This tests that you can compile and flash your PyBadge with TinyGo code, by blin
 
 
 ```
-tinygo flash -target pybadge ./step0
+tinygo flash -target gobadge ./step0
 ```
 
 ![flashing the board](../../assets/getting_flashed.jpg)
@@ -65,7 +65,7 @@ Once the PyBadge is flashed correctly, the built-in LED labeled "D13" (on the ba
 Run the code.
 
 ```
-tinygo flash -target pybadge ./step1
+tinygo flash -target gobadge ./step1
 ```
 
 When you press the START button, the built-in LED should turn on.
@@ -81,7 +81,7 @@ the _SELECT_ button is pressed instead of the _START_ button.
 Run the code.
 
 ```
-tinygo flash -target pybadge ./step2
+tinygo flash -target gobadge ./step2
 ```
 
 ![step 2 location](./assets/step2.jpg)
@@ -98,7 +98,7 @@ The 5 neopixels should light up green and red alternatively.
 Run the code.
 
 ```
-tinygo flash -target pybadge ./step3
+tinygo flash -target gobadge ./step3
 ```
 
 The 5 neopixels should light up in different colors depending on which button you press.
@@ -116,7 +116,7 @@ After deploying it should look like this:
 Run the code.
 
 ```
-tinygo flash -target pybadge ./step4
+tinygo flash -target gobadge ./step4
 ```
 
 
@@ -125,7 +125,7 @@ tinygo flash -target pybadge ./step4
 Run the code.
 
 ```
-tinygo flash -target pybadge ./step5/main.go
+tinygo flash -target gobadge ./step5/main.go
 ```
 
 The message "Hello Gophers!" should appear on the display.
@@ -139,7 +139,7 @@ The message "Hello Gophers!" should appear on the display.
 Run the code.
 
 ```
-tinygo flash -target pybadge ./step6/main.go
+tinygo flash -target gobadge ./step6/main.go
 ```
 
 ![step6](./assets/step6.jpg)
@@ -154,7 +154,7 @@ When a button is pressed a ring will be shown around its corresponding circle.
 Run the code.
 
 ```
-tinygo flash -target pybadge ./step7
+tinygo flash -target gobadge ./step7
 ```
 
 ![step7](./assets/step7.jpg)
@@ -166,7 +166,7 @@ The display will show a bar for each X,Y,Z axis. Move the Pybadge to see it in a
 Run the code.
 
 ```
-tinygo flash -target pybadge ./step8/main.go
+tinygo flash -target gobadge ./step8/main.go
 ```
 
 Press the buttons and create your melody.

--- a/tutorial/snake/README.md
+++ b/tutorial/snake/README.md
@@ -49,7 +49,7 @@ This step is to get familiar with the display and the drawing functions.
 ![Adafruit PyBadge bootloader](./assets/pybadge_bootloader.jpg)
 
 ```
-tinygo flash -target pybadge ./step0/main.go
+tinygo flash -target gobadge ./step0/main.go
 ```
 
 Once the PyBadge is flashed correctly, a green pixel will appear on the middle of the screen. Feel free to change the values of `display.SetPixel` (towards the bottom of the ./step0/main.go file) and see where the pixel appears!
@@ -61,7 +61,7 @@ Once the PyBadge is flashed correctly, a green pixel will appear on the middle o
 Run the code.
 
 ```
-tinygo flash -target pybadge ./step1/main.go
+tinygo flash -target gobadge ./step1/main.go
 ```
 
 ![A bigger pixel](./assets/step1.jpg)
@@ -73,7 +73,7 @@ Instead of a pixel, we are drawing a 10x10 green rectangle.
 Run the code.
 
 ```
-tinygo flash -target pybadge ./step2/main.go
+tinygo flash -target gobadge ./step2/main.go
 ```
 
 We listen to the input buttons and move our rectangle across the display.
@@ -85,7 +85,7 @@ We listen to the input buttons and move our rectangle across the display.
 Run the code.
 
 ```
-tinygo flash -target pybadge ./step3/main.go
+tinygo flash -target gobadge ./step3/main.go
 ```
 
 Have you noticed the snake at the previous step was kind of slow? That was because display.FillScreen draws the whole display and is a slow process, we could improve the speed if only re-draw the pixels that has 
@@ -98,7 +98,7 @@ changed.
 Run the code.
 
 ```
-tinygo flash -target pybadge ./step4/main.go
+tinygo flash -target gobadge ./step4/main.go
 ```
 
 In the previous step, the 10x10 _snake_ was moving by 1 pixel each time, we need to divide our display (160x128) in a 10x10 grid so the snake will move a whole block each time.
@@ -110,7 +110,7 @@ In the previous step, the 10x10 _snake_ was moving by 1 pixel each time, we need
 Run the code.
 
 ```
-tinygo flash -target pybadge ./step5/main.go
+tinygo flash -target gobadge ./step5/main.go
 ```
 
 Our little snake grew from 1 block to 3 block length.
@@ -122,7 +122,7 @@ Our little snake grew from 1 block to 3 block length.
 Feed our snake some red apples so it can grow
 
 ```
-tinygo flash -target pybadge ./step6/main.go
+tinygo flash -target gobadge ./step6/main.go
 ```
 
 ![I wanna grow up!](./assets/step6.jpg)
@@ -134,7 +134,7 @@ The display will show some blue circles. When a button is pressed a ring will be
 Run the code.
 
 ```
-tinygo flash -target pybadge ./step7/main.go
+tinygo flash -target gobadge ./step7/main.go
 ```
 
 ![Let's play](./assets/step7_01.gif)


### PR DESCRIPTION
This PR changes the target name to `gobadge` thanks to TinyGo 0.30

It also adds an important note about flashing new badges to put the badge into bootloader mode.